### PR TITLE
Add subsection with frequent bloggers to NativeScript resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list. Feel fr
 - [LokiJS Example](https://github.com/TobiasHennig/loki-nativescript-adapter-example) - An example application for the Loki NativeScript adapter.
 - [TabView Example](https://github.com/lazaromenezes/nativescript-tabview-example) - Short example of using NativeScript TabView.
 - [Animated Sidebar Menu](https://github.com/emiloberg/nativescript-animated-sidebar-menu-example) - Create an animated sidebar menu without any external dependencies.
+- [PropertyCross Implementation](https://github.com/tastejs/PropertyCross/tree/master/nativescript) - An example app for searching UK property listings build with Angular 2 + NativeScript.
 
 #### Project Boilerplates
 

--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list. Feel fr
 - [Martin Keiblinger at ViennaJS | 14-Apr-16](https://www.youtube.com/watch?v=SnxLpT5tQig) - NativeScript to build native Apps with JavaScript.
 - [TJ VanToll and Jen Looper at NativeScript Jax | 14-Apr-16](https://www.youtube.com/watch?v=Y2F5cHQuaIc) - Sharing Code Between Web and Native Apps.
 - [Sebastian Witalec at Angular Connect | 21-Oct-15](https://www.youtube.com/watch?v=4SbiiyRSIwo&list=PLAnub1yHrv1BlPPCPEq9bcPpguMWS3POA) - Building native mobile apps with Angular 2 0 and NativeScript​.
+- [Alex Vakrilov at NaticeScript Developer Day 2016 | 11-Okt-16](https://youtu.be/jH5I8ZPzXWE?list=PLiKWVuUOQtPY4XpvBSu41tobgm3YR99-r) - Using Redux For Building Applications With NativeScript Angular.
 
 #### Tutorials
 

--- a/README.md
+++ b/README.md
@@ -239,6 +239,9 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list. Feel fr
 - [Hristo Borisov | 12-Jun-15](http://developer.telerik.com/products/offline-support-for-hybrid-web-and-nativescript-apps/) - Offline Support for Hybrid, Web and NativeScript Apps.
 - [Kamen Velikov | 19-May-15](https://www.nativescript.org/blog/how-to-enable-healthkit-in-your-nativescript-application/) - Enable HealthKit in your NativeScript application.
 - [TJ VanToll | 23-Mar-15](http://developer.telerik.com/featured/building-your-own-nativescript-modules-for-npm/) - Building Your Own NativeScript Modules for npm.
+- [Mihail Slavchev | 12-Jun-14](http://developer.telerik.com/featured/nativescript-android/) - Internals of the NativeScript Android runtime explained.
+- [TJ VanToll | 16-Feb-15](http://developer.telerik.com/featured/nativescript-works/) - TJ VanToll explains how NativeScript works.
+- [TJ VanToll | 22-May-15](https://www.tjvantoll.com/2015/05/22/linting-javascript-in-nativescript-apps/) - Linting JavaScript in NativeScript Apps.
 
 #### Talks
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list. Feel fr
 <br>
 > <h3>NativeScript Ecosystem</h3>
 
-#### Documentation
+#### Official
 
 - [Developer Docs](https://docs.nativescript.org/) - NativeScript Documentation.
 - [API Reference](https://docs.nativescript.org/api-reference/globals.html) - NativeScript API.

--- a/README.md
+++ b/README.md
@@ -43,15 +43,19 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list. Feel fr
 - [Developer Docs](https://docs.nativescript.org/) - NativeScript Documentation.
 - [API Reference](https://docs.nativescript.org/api-reference/globals.html) - NativeScript API.
 - [Roadmap](https://www.nativescript.org/roadmap) - NativeScript Project Roadmap.
+- [Newsletter](https://www.nativescript.org/nativescript-newsletter)
+- [NativeScript Blog](https://www.nativescript.org/blog)
+- [Upcoming Events](https://www.nativescript.org/events)
+- [FAQ](https://www.nativescript.org/faq) - Frequently asked questions about NativeScript.
+- [Telerik Developer Digest](http://digest.telerik.com/) - Software development articles from the Telerik Developer Network.
 
 #### Community
 
 - [Request Slack Invite](http://developer.telerik.com/wp-login.php?action=slack-invitation)
 - [NativeScript StackOverflow](http://stackoverflow.com/questions/tagged/nativescript)
 - [NativeScript Infowrap](http://www.infowrap.com/nativescript/overview?collaborate=16da0720-70ad-4183-8ec9-de034f1644e5&token=c1b8db1a-b70c-4afb-8950-f7c21f40327d)
-- [NativeScript Blog](https://www.nativescript.org/blog)
-- [Upcoming Events](https://www.nativescript.org/events)
-- [Newsletter](https://www.nativescript.org/nativescript-newsletter)
+- [NativeScript Snacks](http://www.nativescriptsnacks.com/) - Bite-sized videos and code snippets for learning purposes.
+- [NativeScript Rocks](http://nativescript.rocks/) - Website containing many community resources maintained by Nathanael Anderson.
 
 <br>
 > <h3>Plugins</h3>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list. Feel fr
 
 ### Table of Contents
  - [Resources](#resources)
-   - [Documentation](#documentation)
+   - [Official](#official)
    - [Community](#community)
  - [Plugins](#plugins)
    - [Interface](#interface)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list. Feel fr
  - [Resources](#resources)
    - [Official](#official)
    - [Community](#community)
+     - [Bloggers](#bloggers)
  - [Plugins](#plugins)
    - [Interface](#interface)
      - [Visual Components](#visual-components)
@@ -56,6 +57,13 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list. Feel fr
 - [NativeScript Infowrap](http://www.infowrap.com/nativescript/overview?collaborate=16da0720-70ad-4183-8ec9-de034f1644e5&token=c1b8db1a-b70c-4afb-8950-f7c21f40327d)
 - [NativeScript Snacks](http://www.nativescriptsnacks.com/) - Bite-sized videos and code snippets for learning purposes.
 - [NativeScript Rocks](http://nativescript.rocks/) - Website containing many community resources maintained by Nathanael Anderson.
+
+##### Bloggers
+
+- [List Main NativeScript Bloggers](https://www.nativescript.org/resources#nativescript-bloggers)
+- [TJ VanToll](https://www.tjvantoll.com/blog/)
+- [Peter Messenger](http://stonecourier.blogspot.be/)
+- [Ben Elliott](https://therankamateur.co.uk/)
 
 <br>
 > <h3>Plugins</h3>


### PR DESCRIPTION
Hi,

It could be useful to add some frequent NativeScript Bloggers to the list of resources. People who want to stay up-to-date on the latest developments can add the links to their RSS readers.

Kind Regards,
Ruben