### PR TITLE
Add subsection with frequent bloggers to NativeScript resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list. Feel fr
 
 - [Main NativeScript Bloggers](https://www.nativescript.org/resources#nativescript-bloggers)
 - [NS Bloggers](http://www.nsbloggers.com/feeds.cfm) - Extensive list of NativeScript bloggers maintained by community.
-- [Peter Messenger](http://stonecourier.blogspot.be/) - Senior developer at [KipMcGrath Education Centres](http://www.kipmcgrath.com/) and Web developer.
+- [Peter Messenger](http://stonecourier.blogspot.be/) - Senior developer at [KipMcGrath Education Centres](http://www.kipmcgrath.com/). Skilled Silverlight, Web and Mobile application developer.
 
 <br>
 > <h3>Plugins</h3>

--- a/README.md
+++ b/README.md
@@ -60,10 +60,9 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list. Feel fr
 
 ##### Bloggers
 
-- [List Main NativeScript Bloggers](https://www.nativescript.org/resources#nativescript-bloggers)
-- [TJ VanToll](https://www.tjvantoll.com/blog/)
-- [Peter Messenger](http://stonecourier.blogspot.be/)
-- [Ben Elliott](https://therankamateur.co.uk/)
+- [Main NativeScript Bloggers](https://www.nativescript.org/resources#nativescript-bloggers)
+- [NS Bloggers](http://www.nsbloggers.com/feeds.cfm) - Extensive list of NativeScript bloggers maintained by community.
+- [Peter Messenger](http://stonecourier.blogspot.be/) - Senior developer at [KipMcGrath Education Centres](http://www.kipmcgrath.com/) and Web developer.
 
 <br>
 > <h3>Plugins</h3>

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list. Feel fr
  - [Resources](#resources)
    - [Official](#official)
    - [Community](#community)
+     - [Bloggers](#bloggers)
  - [Plugins](#plugins)
    - [Interface](#interface)
      - [Visual Components](#visual-components)
@@ -56,6 +57,13 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list. Feel fr
 - [NativeScript Infowrap](http://www.infowrap.com/nativescript/overview?collaborate=16da0720-70ad-4183-8ec9-de034f1644e5&token=c1b8db1a-b70c-4afb-8950-f7c21f40327d)
 - [NativeScript Snacks](http://www.nativescriptsnacks.com/) - Bite-sized videos and code snippets for learning purposes.
 - [NativeScript Rocks](http://nativescript.rocks/) - Website containing many community resources maintained by Nathanael Anderson.
+
+##### Bloggers
+
+- [List Main NativeScript Bloggers](https://www.nativescript.org/resources#nativescript-bloggers)
+- [TJ VanToll](https://www.tjvantoll.com/blog/)
+- [Peter Messenger](http://stonecourier.blogspot.be/)
+- [Ben Elliott](https://therankamateur.co.uk/)
 
 <br>
 > <h3>Plugins</h3>


### PR DESCRIPTION
Hi,

It could be useful to add some frequent NativeScript Bloggers to the list of resources. People who want to stay up-to-date on the latest developments can add the links to their RSS readers.

Kind Regards,
Ruben